### PR TITLE
Subresource Integrity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,8 @@
                 "ts-essentials": "^9.1.2",
                 "ts-jest": "^28.0.5",
                 "twin.macro": "^3.4.1",
-                "typescript": "^4.7.3"
+                "typescript": "^4.7.3",
+                "vite-plugin-manifest-sri": "^0.2.0"
             },
             "engines": {
                 "node": ">=20.0"
@@ -12770,6 +12771,12 @@
                 "picocolors": "^1.0.0",
                 "picomatch": "^2.3.1"
             }
+        },
+        "node_modules/vite-plugin-manifest-sri": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-manifest-sri/-/vite-plugin-manifest-sri-0.2.0.tgz",
+            "integrity": "sha512-Zt5jt19xTIJ91LOuQTCtNG7rTFc5OziAjBz2H5NdCGqaOD1nxrWExLhcKW+W4/q8/jOPCg/n5ncYEQmqCxiGQQ==",
+            "dev": true
         },
         "node_modules/walker": {
             "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
         "ts-essentials": "^9.1.2",
         "ts-jest": "^28.0.5",
         "twin.macro": "^3.4.1",
-        "typescript": "^4.7.3"
+        "typescript": "^4.7.3",
+        "vite-plugin-manifest-sri": "^0.2.0"
     },
     "scripts": {
         "lint": "eslint ./resources/scripts/**/*.{ts,tsx} --ext .ts,.tsx",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import react from '@vitejs/plugin-react';
 import laravel from 'laravel-vite-plugin';
 import { dirname, resolve } from 'pathe';
 import { fileURLToPath } from 'node:url';
+import manifestSRI from 'vite-plugin-manifest-sri';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
@@ -28,6 +29,7 @@ export default defineConfig({
 
     plugins: [
         laravel('resources/scripts/index.tsx'),
+        manifestSRI(),
         react({
             babel: {
                 plugins: ['babel-plugin-macros', 'babel-plugin-styled-components'],


### PR DESCRIPTION
This PR implements adding integrity hashes to the vite manifest and injects them at render time. SRI is important as it ensures that the panel's bundled JS isn't corrupted or tampered with before sending it to the browser. This is ready to be deployed in prod now