### PR TITLE
Radix Checkboxes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
     "name": "pyrodactyl",
-    "version": "0.47.0-alpha",
+    "version": "0.49.0-alpha",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pyrodactyl",
-            "version": "0.47.0-alpha",
+            "version": "0.49.0-alpha",
             "dependencies": {
                 "@headlessui/react": "^1.7.18",
                 "@preact/signals-react": "^2.0.0",
+                "@radix-ui/react-checkbox": "^1.0.4",
                 "@radix-ui/react-context-menu": "^2.1.5",
                 "@radix-ui/react-dropdown-menu": "^2.0.6",
                 "@radix-ui/react-icons": "^1.3.0",
@@ -2360,6 +2361,36 @@
                 }
             }
         },
+        "node_modules/@radix-ui/react-checkbox": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.0.4.tgz",
+            "integrity": "sha512-CBuGQa52aAYnADZVt/KBQzXrwx6TqnlwtcIPGtVt5JkkzQwMOLJjPukimhfKEr4GQNd43C+djUh5Ikopj8pSLg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/primitive": "1.0.1",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-context": "1.0.1",
+                "@radix-ui/react-presence": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-use-controllable-state": "1.0.1",
+                "@radix-ui/react-use-previous": "1.0.1",
+                "@radix-ui/react-use-size": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@radix-ui/react-collection": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
@@ -2903,6 +2934,23 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
             "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-previous": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.1.tgz",
+            "integrity": "sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==",
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dependencies": {
         "@headlessui/react": "^1.7.18",
         "@preact/signals-react": "^2.0.0",
+        "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-context-menu": "^2.1.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-icons": "^1.3.0",

--- a/resources/scripts/components/elements/CheckboxNew.tsx
+++ b/resources/scripts/components/elements/CheckboxNew.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
+import { CheckIcon } from '@radix-ui/react-icons';
+
+import { cn } from '@/lib/utils';
+
+const Checkbox = React.forwardRef<
+    React.ElementRef<typeof CheckboxPrimitive.Root>,
+    React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+    <CheckboxPrimitive.Root
+        ref={ref}
+        className={cn(
+            'peer h-5 w-5 shrink-0 rounded-md border-2 border-[#ffffff66] shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[deepskyblue] disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-brand data-[state=checked]:text-primary-foreground',
+            className,
+        )}
+        {...props}
+    >
+        <CheckboxPrimitive.Indicator className={cn('flex items-center justify-center text-current')}>
+            <CheckIcon className='h-4 w-4' />
+        </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/resources/scripts/components/server/files/FileManagerBreadcrumbs.tsx
+++ b/resources/scripts/components/server/files/FileManagerBreadcrumbs.tsx
@@ -37,7 +37,7 @@ export default ({ renderLeft, withinFileEditor, isNewFile }: Props) => {
             });
 
     return (
-        <div className={`group flex flex-grow-0 items-center text-sm text-zinc-500 overflow-x-hidden`}>
+        <div className={`group flex flex-grow-0 items-center text-sm overflow-x-hidden`}>
             {renderLeft || <div className={`w-12`} />}
             {/* displaying "home" is so useless and needlessly confusing */}
             {/* <span className={`px-1 text-zinc-300`}>home</span>
@@ -88,7 +88,7 @@ export default ({ renderLeft, withinFileEditor, isNewFile }: Props) => {
                     <span key={index} className={`px-1 text-zinc-300`}>
                         {crumb.name}
                     </span>
-                )
+                ),
             )}
             {file && (
                 <Fragment>

--- a/resources/scripts/components/server/files/FileManagerContainer.tsx
+++ b/resources/scripts/components/server/files/FileManagerContainer.tsx
@@ -15,7 +15,7 @@ import UploadButton from '@/components/server/files/UploadButton';
 import ServerContentBlock from '@/components/elements/ServerContentBlock';
 import { useStoreActions } from '@/state/hooks';
 import ErrorBoundary from '@/components/elements/ErrorBoundary';
-import { FileActionCheckbox } from '@/components/server/files/SelectFileCheckbox';
+import { Checkbox } from '@/components/elements/CheckboxNew';
 import { hashToPath } from '@/helpers';
 // import style from './style.module.css';
 import NewFileButton from './NewFileButton';
@@ -48,8 +48,13 @@ export default () => {
         mutate();
     }, [directory]);
 
-    const onSelectAllClick = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setSelectedFiles(e.currentTarget.checked ? files?.map((file) => file.name) || [] : []);
+    const onSelectAllClick = () => {
+        console.log('files', files);
+        setSelectedFiles(
+            selectedFilesLength === (files?.length === 0 ? -1 : files?.length)
+                ? []
+                : files?.map((file) => file.name) || [],
+        );
     };
 
     if (error) {
@@ -73,14 +78,10 @@ export default () => {
                 <div className={'flex flex-wrap-reverse md:flex-nowrap mb-4'}>
                     <FileManagerBreadcrumbs
                         renderLeft={
-                            <FileActionCheckbox
-                                type={'checkbox'}
-                                className='ml-6 mr-4'
-                                // todo: find a user friendly way to implement this
-                                // className={`opacity-0 -ml-8 mr-4`}
-                                // className='group-hover:opacity-100 group-focus:opacity-100 group-hover:ml-6'
+                            <Checkbox
+                                className='ml-[1.6rem] mr-4'
                                 checked={selectedFilesLength === (files?.length === 0 ? -1 : files?.length)}
-                                onChange={onSelectAllClick}
+                                onCheckedChange={() => onSelectAllClick()}
                             />
                         }
                     />

--- a/resources/scripts/components/server/files/FileObjectRow.tsx
+++ b/resources/scripts/components/server/files/FileObjectRow.tsx
@@ -11,10 +11,7 @@ import { usePermissions } from '@/plugins/usePermissions';
 import { join } from 'pathe';
 import { bytesToString } from '@/lib/formatters';
 import styles from './style.module.css';
-import {
-    ContextMenu,
-    ContextMenuTrigger,
-} from '@/components/elements/ContextMenu';
+import { ContextMenu, ContextMenuTrigger } from '@/components/elements/ContextMenu';
 import FileDropdownMenu from './FileDropdownMenu';
 
 function Clickable({ file, children }: { file: FileObject; children: ReactNode }) {
@@ -42,7 +39,7 @@ const FileObjectRow = ({ file }: { file: FileObject }) => (
             <div className={styles.file_row} key={file.name}>
                 <SelectFileCheckbox name={file.name} />
                 <MemoizedClickable file={file}>
-                    <div className={`flex-none text-zinc-400 ml-6 mr-4 text-lg pl-3`}>
+                    <div className={`flex-none text-zinc-400 mr-4 text-lg pl-3`}>
                         {file.isFile ? (
                             // todo handle other types of files. ugh
                             <svg
@@ -93,7 +90,9 @@ const FileObjectRow = ({ file }: { file: FileObject }) => (
                     </div>
                     <div className={`flex-1 truncate font-bold text-sm`}>{file.name}</div>
                     {file.isFile && (
-                        <div className={`w-1/6 text-right mr-4 hidden sm:block text-xs`}>{bytesToString(file.size)}</div>
+                        <div className={`w-1/6 text-right mr-4 hidden sm:block text-xs`}>
+                            {bytesToString(file.size)}
+                        </div>
                     )}
                     <div className={`w-1/5 text-right mr-4 hidden md:block text-xs`} title={file.modifiedAt.toString()}>
                         {Math.abs(differenceInHours(file.modifiedAt, new Date())) > 48

--- a/resources/scripts/components/server/files/SelectFileCheckbox.tsx
+++ b/resources/scripts/components/server/files/SelectFileCheckbox.tsx
@@ -1,17 +1,5 @@
 import { ServerContext } from '@/state/server';
-import styled from 'styled-components';
-import Input from '@/components/elements/Input';
-
-export const FileActionCheckbox = styled(Input)`
-    && {
-        background: transparent;
-        border: #ffffffaa;
-
-        &:not(:checked):hover {
-            border-color: #ffffff55;
-        }
-    }
-`;
+import { Checkbox } from '@/components/elements/CheckboxNew';
 
 export default ({ name }: { name: string }) => {
     const isChecked = ServerContext.useStoreState((state) => state.files.selectedFiles.indexOf(name) >= 0);
@@ -19,20 +7,12 @@ export default ({ name }: { name: string }) => {
     const removeSelectedFile = ServerContext.useStoreActions((actions) => actions.files.removeSelectedFile);
 
     return (
-        <label className={`flex-none px-4 py-2 absolute self-center z-30 cursor-pointer`}>
-            <FileActionCheckbox
-                name={'selectedFiles'}
-                value={name}
-                checked={isChecked}
-                type={'checkbox'}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    if (e.currentTarget.checked) {
-                        appendSelectedFile(name);
-                    } else {
-                        removeSelectedFile(name);
-                    }
-                }}
-            />
-        </label>
+        <Checkbox
+            className='ml-4'
+            name={'selectedFiles'}
+            value={name}
+            checked={isChecked}
+            onCheckedChange={isChecked ? () => removeSelectedFile(name) : () => appendSelectedFile(name)}
+        />
     );
 };

--- a/resources/scripts/components/server/files/style.module.css
+++ b/resources/scripts/components/server/files/style.module.css
@@ -29,4 +29,8 @@
     &[data-state='open'] {
         @apply bg-[#ffffff12];
     }
+
+    &:has(button[data-state='checked']) {
+        @apply bg-[#2a2021];
+    }
 }


### PR DESCRIPTION
This PR adds Radix UI checkboxes that will gradually replace all instances of the vanilla styled-components checkboxes. This is currently implemented in the file manager, which (finally) replicate how it looks in Figma!