### PR TITLE
PYRO-56 Virtualized file manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pyrodactyl",
-    "version": "1.1.4",
+    "version": "1.1.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pyrodactyl",
-            "version": "1.1.4",
+            "version": "1.1.6",
             "dependencies": {
                 "@codemirror/autocomplete": "^6.15.0",
                 "@codemirror/commands": "^6.3.3",
@@ -26,6 +26,7 @@
                 "@sentry/vite-plugin": "^2.16.0",
                 "@tailwindcss/forms": "^0.5.7",
                 "@tailwindcss/line-clamp": "^0.4.4",
+                "@tanstack/react-virtual": "^3.2.0",
                 "@xterm/addon-fit": "^0.9.0",
                 "@xterm/addon-search": "^0.14.0",
                 "@xterm/addon-web-links": "^0.10.0",
@@ -4199,11 +4200,11 @@
             }
         },
         "node_modules/@tanstack/react-virtual": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.1.3.tgz",
-            "integrity": "sha512-YCzcbF/Ws/uZ0q3Z6fagH+JVhx4JLvbSflgldMgLsuvB8aXjZLLb3HvrEVxY480F9wFlBiXlvQxOyXb5ENPrNA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.2.0.tgz",
+            "integrity": "sha512-OEdMByf2hEfDa6XDbGlZN8qO6bTjlNKqjM3im9JG+u3mCL8jALy0T/67oDI001raUUPh1Bdmfn4ZvPOV5knpcg==",
             "dependencies": {
-                "@tanstack/virtual-core": "3.1.3"
+                "@tanstack/virtual-core": "3.2.0"
             },
             "funding": {
                 "type": "github",
@@ -4215,9 +4216,9 @@
             }
         },
         "node_modules/@tanstack/virtual-core": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.1.3.tgz",
-            "integrity": "sha512-Y5B4EYyv1j9V8LzeAoOVeTg0LI7Fo5InYKgAjkY1Pu9GjtUwX/EKxNcU7ng3sKr99WEf+bPTcktAeybyMOYo+g==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.2.0.tgz",
+            "integrity": "sha512-P5XgYoAw/vfW65byBbJQCw+cagdXDT/qH6wmABiLt4v4YBT2q2vqCOhihe+D1Nt325F/S/0Tkv6C5z0Lv+VBQQ==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/tannerlinsley"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "@sentry/vite-plugin": "^2.16.0",
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/line-clamp": "^0.4.4",
+        "@tanstack/react-virtual": "^3.2.0",
         "@xterm/addon-fit": "^0.9.0",
         "@xterm/addon-search": "^0.14.0",
         "@xterm/addon-web-links": "^0.10.0",

--- a/resources/scripts/components/server/files/FileObjectRow.tsx
+++ b/resources/scripts/components/server/files/FileObjectRow.tsx
@@ -39,7 +39,7 @@ const FileObjectRow = ({ file }: { file: FileObject }) => (
             <div className={styles.file_row} key={file.name}>
                 <SelectFileCheckbox name={file.name} />
                 <MemoizedClickable file={file}>
-                    <div className={`flex-none text-zinc-400 mr-4 text-lg pl-3`}>
+                    <div className={`flex-none text-zinc-400 mr-4 text-lg pl-3 mb-0.5`}>
                         {file.isFile ? (
                             // todo handle other types of files. ugh
                             <svg


### PR DESCRIPTION
Fixes PYRO-56. Effectively removes the 250 file view limit as virtualization ensures only the file rows that are visible on-screen are rendered. The only costs to having more than 250 files being available is the burden on the API (should not be much) and the serialization on the client (literally, just sorting the files array. Theoretically should be okay up to 5000 files). 

This implementation may have bugs but everything seemed to work OK from my testing.