### PR TITLE
fix: remove stray 't'

### DIFF
--- a/app/Http/Controllers/Admin/NodesController.php
+++ b/app/Http/Controllers/Admin/NodesController.php
@@ -1,4 +1,4 @@
-t<?php
+<?php
 
 namespace Pterodactyl\Http\Controllers\Admin;
 


### PR DESCRIPTION
Trying to create a new node (clicking the **Create new** button) or attempting to add a new allocation results in this error:
`[2025-08-18 14:51:00] production.ERROR: Namespace declaration statement has to be the very first statement or after any declare call in the script {"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0): Namespace declaration statement has to be the very first statement or after any declare call in the script at /app/app/Http/Controllers/Admin/NodesController.php:3)`
along with a 500 Server Error.

I believe there was a stray 't' within the source of the NodesController.php file.