### PR TITLE
fix: handle Cloudflare subdomain DNS records correctly

### DIFF
--- a/app/Services/Dns/Providers/CloudflareProvider.php
+++ b/app/Services/Dns/Providers/CloudflareProvider.php
@@ -4,6 +4,7 @@ namespace Pterodactyl\Services\Dns\Providers;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
 use Pterodactyl\Contracts\Dns\DnsProviderInterface;
 use Pterodactyl\Exceptions\Dns\DnsProviderException;
 use Illuminate\Support\Facades\Log;
@@ -62,6 +63,8 @@ class CloudflareProvider implements DnsProviderInterface
     public function createRecord(string $domain, string $name, string $type, $content, int $ttl = 300): string
     {
         $zoneId = $this->getZoneId($domain);
+        $displayName = $name;
+        $name = $this->normalizeRecordName($domain, $name);
 
 
         try {
@@ -102,8 +105,14 @@ class CloudflareProvider implements DnsProviderInterface
             /* ]); */
 
             return $data['result']['id'];
+        } catch (RequestException $e) {
+            throw DnsProviderException::recordCreationFailed(
+                $domain,
+                $displayName,
+                $this->getRequestExceptionMessage($e)
+            );
         } catch (GuzzleException $e) {
-            throw DnsProviderException::recordCreationFailed($domain, $name, 'DNS service temporarily unavailable.');
+            throw DnsProviderException::recordCreationFailed($domain, $displayName, 'DNS service temporarily unavailable.');
         }
     }
 
@@ -199,7 +208,7 @@ class CloudflareProvider implements DnsProviderInterface
         try {
             $params = [];
             if ($name) {
-                $params['name'] = $name;
+                $params['name'] = $this->normalizeRecordName($domain, $name);
             }
             if ($type) {
                 $params['type'] = strtoupper($type);
@@ -219,6 +228,44 @@ class CloudflareProvider implements DnsProviderInterface
         } catch (GuzzleException $e) {
             throw DnsProviderException::connectionFailed('cloudflare', 'DNS service temporarily unavailable.');
         }
+    }
+
+    private function normalizeRecordName(string $domain, string $name): string
+    {
+        $domain = rtrim($domain, '.');
+        $name = rtrim($name, '.');
+
+        if ($name === '' || $name === '@') {
+            return $domain;
+        }
+
+        if ($name === $domain || str_ends_with($name, '.' . $domain)) {
+            return $name;
+        }
+
+        return $name . '.' . $domain;
+    }
+
+    private function getRequestExceptionMessage(RequestException $e): string
+    {
+        $response = $e->getResponse();
+        if (!$response) {
+            return 'DNS service temporarily unavailable.';
+        }
+
+        $data = json_decode((string) $response->getBody(), true);
+        if (!is_array($data)) {
+            return 'DNS provider rejected the record creation request.';
+        }
+
+        $messages = [];
+        foreach ($data['errors'] ?? [] as $error) {
+            if (!empty($error['message'])) {
+                $messages[] = $error['message'];
+            }
+        }
+
+        return empty($messages) ? 'DNS provider rejected the record creation request.' : implode(' ', $messages);
     }
 
     /**

--- a/app/Services/Subdomain/SubdomainManagementService.php
+++ b/app/Services/Subdomain/SubdomainManagementService.php
@@ -630,17 +630,26 @@ class SubdomainManagementService
      */
     private function normalizeIpAddresses(array $dnsRecords, server $server): array
     {
-        $useAlias = $server->node->trust_alias;
+        $useAlias = (bool) $server->node->trust_alias;
+        $allocationIp = $server->allocation->ip;
+        $allocationAlias = $server->allocation->ip_alias;
+
         foreach ($dnsRecords as &$record) {
-            if ($useAlias == 1) {
-                $record['content'] = $server->allocation->ip_alias;
-            } else if ($record['type'] === 'A' && isset($record['content']) && $useAlias == 0) {
-                // Convert localhost to 127.0.0.1 for A records
-                if (strtolower($record['content']) === 'localhost' &&  $useAlias == 0) {
-                    $record['content'] = '127.0.0.1';
-                }
+            if (($record['type'] ?? null) !== 'A' || !array_key_exists('content', $record)) {
+                continue;
+            }
+
+            if ($useAlias) {
+                $record['content'] = !empty($allocationAlias) ? $allocationAlias : $allocationIp;
+                continue;
+            }
+
+            // Convert localhost to 127.0.0.1 for A records
+            if (strtolower($record['content']) === 'localhost') {
+                $record['content'] = '127.0.0.1';
             }
         }
+
         return $dnsRecords;
     }
 


### PR DESCRIPTION
## Summary

- normalize Cloudflare record names to fully qualified names before create and list calls
- preserve Cloudflare API error messages when DNS record creation fails
- avoid writing null A record content when allocation alias trust is enabled but the alias is blank

## Why

Subdomain allocation failed for Cloudflare-backed domains for two separate reasons:

- the Cloudflare provider was not normalizing record names consistently for zone-scoped API calls
- the provider swallowed Cloudflare response details, which turned token permission problems into a generic service outage

There was also a follow-on bug where enabling allocation alias trust with a blank `ip_alias` could produce invalid A records with empty content.

## Validation

- applied and syntax-checked the same changes on the live panel host with `php -l`
